### PR TITLE
Add -- to separate files from revisions

### DIFF
--- a/scripts/extractChanges.sh
+++ b/scripts/extractChanges.sh
@@ -2,5 +2,5 @@
  
 for i in `git ls-files`
 do 
-        git log --follow -p $i |grep "^commit" |awk "{ print \"$i\tmodified-in\t\" \$2 }"
+        git log --follow -p -- $i |grep "^commit" |awk "{ print \"$i\tmodified-in\t\" \$2 }"
 done


### PR DESCRIPTION
So that if you have a file "foo" and a branch "foo", git doesn't complain.
