### PR TITLE
Work even if user has customized git log output

### DIFF
--- a/scripts/extractChanges.sh
+++ b/scripts/extractChanges.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
- 
-for i in `git ls-files`
-do 
-        git log --follow -p -- $i |grep "^commit" |awk "{ print \"$i\tmodified-in\t\" \$2 }"
+
+for i in `git ls-files`; do
+	git log --pretty="$i%x09modified-in%x09%H" --follow $i
 done


### PR DESCRIPTION
My standard git config customizes the log output which breaks your script. Fixing it to always output the correctly formatted values directly from Git will make it work with any gitconfig and significantly reduce the number of forks necessary on large projects.
