### PR TITLE
Add alternate viewers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ bash scripts/evSource.sh addr://your/fav/git/repository /path/to/a/local/working
 
 and once all is done, you can collect your results from `/path/to/a/local/working/folder/results`.
 
+## Visualizing results
+
+PDF result is rendered automatically with igraph in the results folder
+
+Other options
+D3 based viewer http://pnavarrc.github.io/evsrc-visualization/dist/
+Cytoscape.js viewer here http://cmdcolin.github.io/evsrc-cytoscape/
+
 # Contact
 B. Arman Aksoy - [arman@aksoy.org](mailto:arman@aksoy.org)
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ and once all is done, you can collect your results from `/path/to/a/local/workin
 
 ## Visualizing results
 
-PDF result is rendered automatically with igraph in the results folder
+PDF results that are rendered with igraph are automatically generated in the results folder.
 
-Other options
+By default, correlation thresholds .1, .3, .5, .7, .9 are generated via the R script. If you receive no output, you may try smaller thresholds
+
+Other options for visualizing the results
+
 D3 based viewer http://pnavarrc.github.io/evsrc-visualization/dist/
 Cytoscape.js viewer here http://cmdcolin.github.io/evsrc-cytoscape/
 


### PR DESCRIPTION
I went ahead and added a section to the README.md called "Visualizing results"

It includes the D3 viewer and Cytoscape JS viewer as well as a note about what to do if there is an empty results folder (which happened to me on a large repo)

Let me know if that helps!